### PR TITLE
Fix for strict error

### DIFF
--- a/emc2-enhanced-menu-editor.php
+++ b/emc2-enhanced-menu-editor.php
@@ -238,7 +238,7 @@ class emc2_enhanced_menu_walker extends Walker_Nav_Menu {
         $this->target = $target_menu;
     }
 
-    function start_el(&$output, $item, $depth, $args) {
+    function start_el(&$output, $item, $depth = 0, $args = array(), $id = 0) {
         $this->assoc[$item->ID] = wp_update_nav_menu_item(
             $this->target, //new menu target
             0,


### PR DESCRIPTION
I experienced next error after installed this plugin:

Strict standards: Declaration of emc2_enhanced_menu_walker::start_el() should be compatible with Walker_Nav_Menu::start_el(&$output, $item, $depth = 0, $args = Array, $id = 0) in emc2-enhanced-menu-editor.php on line 262

So I fixed it by updating method signature.
Please update plugin.
